### PR TITLE
Target tracking, terrain, and ROS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is a fork of [Teddy-Liao/walk-these-ways-go2](https://github.com/Teddy-Liao/walk-these-ways-go2). It is designed to provide a simulation environment and locomotion policy as part of [this (private) repo](https://github.com/ialab-yale/whole_body_ergodic)
+
 # Sim-to-Real project on Unitree Go2
 
 ## Overview 

--- a/go2_gym/envs/base/legged_robot.py
+++ b/go2_gym/envs/base/legged_robot.py
@@ -156,7 +156,7 @@ class LeggedRobot(BaseTask):
         Args:
             env_ids (list[int]): List of environment ids which must be reset
         """
-        pass
+        pass # Once we start the simulation, we don't ever want to reset it
 
         """
 

--- a/go2_gym/envs/base/legged_robot.py
+++ b/go2_gym/envs/base/legged_robot.py
@@ -156,6 +156,9 @@ class LeggedRobot(BaseTask):
         Args:
             env_ids (list[int]): List of environment ids which must be reset
         """
+        pass
+
+        """
 
         if len(env_ids) == 0:
             return
@@ -237,6 +240,7 @@ class LeggedRobot(BaseTask):
 
         for i in range(len(self.lag_buffer)):
             self.lag_buffer[i][env_ids, :] = 0
+        """
 
     def set_idx_pose(self, env_ids, dof_pos, base_state):
         if len(env_ids) == 0:

--- a/go2_gym/utils/terrain.py
+++ b/go2_gym/utils/terrain.py
@@ -31,7 +31,7 @@ class Terrain:
 
         xs, ys = np.meshgrid(np.linspace(-np.pi,np.pi,self.tot_cols), np.linspace(-np.pi,np.pi,self.tot_rows))
 
-        self.height_field_raw = np.int16((2+np.sin(xs) * np.cos(ys)) * 1024) 
+        self.height_field_raw = np.int16((np.sin(xs) * np.cos(ys)) * 1024) 
         print(self.height_field_raw)
         self.cfg.vertical_scale = 2 ** -11
         print(self.height_field_raw)

--- a/go2_gym/utils/terrain.py
+++ b/go2_gym/utils/terrain.py
@@ -29,13 +29,11 @@ class Terrain:
 
         self.initialize_terrains()
 
+        # Create a sinusoidal terrain
+        # TODO: make this configurable
         xs, ys = np.meshgrid(np.linspace(-np.pi,np.pi,self.tot_cols), np.linspace(-np.pi,np.pi,self.tot_rows))
-
-        self.height_field_raw = np.int16((np.sin(xs) * np.cos(ys)) * 1024) 
-        print(self.height_field_raw)
-        self.cfg.vertical_scale = 2 ** -11
-        print(self.height_field_raw)
-
+        self.height_field_raw = np.int16((np.sin(xs) * np.cos(ys)) * 1024) # Heights as int
+        self.cfg.vertical_scale = 2 ** -11 # factor by which to scale
 
         self.heightsamples = self.height_field_raw.ravel()
         if self.type == "trimesh":
@@ -158,7 +156,7 @@ class Terrain:
             pass
         elif choice < proportions[8]:
             terrain_utils.random_uniform_terrain(terrain, min_height=-cfg.terrain_noise_magnitude,
-                                                 max_height=cfg.terrain_noise_magnitude, step=1.0,
+                                                 max_height=cfg.terrain_noise_magnitude, step=1.0, # Changed from step=0.05, not sure why
                                                  downsampled_scale=0.2)
         elif choice < proportions[9]:
             terrain_utils.random_uniform_terrain(terrain, min_height=-0.05, max_height=0.05,

--- a/go2_gym/utils/terrain.py
+++ b/go2_gym/utils/terrain.py
@@ -26,9 +26,18 @@ class Terrain:
 
         self.height_field_raw = np.zeros((self.tot_rows, self.tot_cols), dtype=np.int16)
 
+
         self.initialize_terrains()
 
-        self.heightsamples = self.height_field_raw
+        xs, ys = np.meshgrid(np.linspace(-np.pi,np.pi,self.tot_cols), np.linspace(-np.pi,np.pi,self.tot_rows))
+
+        self.height_field_raw = np.int16((1+np.sin(xs) * np.cos(ys)) * 1024) 
+        print(self.height_field_raw)
+        self.cfg.vertical_scale = 1/1024
+        print(self.height_field_raw)
+
+
+        self.heightsamples = self.height_field_raw.ravel()
         if self.type == "trimesh":
             self.vertices, self.triangles = terrain_utils.convert_heightfield_to_trimesh(self.height_field_raw,
                                                                                          self.cfg.horizontal_scale,
@@ -149,7 +158,7 @@ class Terrain:
             pass
         elif choice < proportions[8]:
             terrain_utils.random_uniform_terrain(terrain, min_height=-cfg.terrain_noise_magnitude,
-                                                 max_height=cfg.terrain_noise_magnitude, step=0.005,
+                                                 max_height=cfg.terrain_noise_magnitude, step=1.0,
                                                  downsampled_scale=0.2)
         elif choice < proportions[9]:
             terrain_utils.random_uniform_terrain(terrain, min_height=-0.05, max_height=0.05,

--- a/go2_gym/utils/terrain.py
+++ b/go2_gym/utils/terrain.py
@@ -31,9 +31,9 @@ class Terrain:
 
         xs, ys = np.meshgrid(np.linspace(-np.pi,np.pi,self.tot_cols), np.linspace(-np.pi,np.pi,self.tot_rows))
 
-        self.height_field_raw = np.int16((1+np.sin(xs) * np.cos(ys)) * 1024) 
+        self.height_field_raw = np.int16((2+np.sin(xs) * np.cos(ys)) * 1024) 
         print(self.height_field_raw)
-        self.cfg.vertical_scale = 1/1024
+        self.cfg.vertical_scale = 2 ** -11
         print(self.height_field_raw)
 
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -78,14 +78,17 @@ def load_env(label, headless=False):
 
     Cfg.env.num_recording_envs = 1
     Cfg.env.num_envs = 1
-    Cfg.terrain.num_rows = 5
-    Cfg.terrain.num_cols = 5
+    Cfg.terrain.num_rows = 10
+    Cfg.terrain.num_cols = 10
     Cfg.terrain.border_size = 0
     Cfg.terrain.center_robots = True
     Cfg.terrain.center_span = 1
-    Cfg.terrain.teleport_robots = True
+    Cfg.terrain.teleport_robots = False
     Cfg.terrain.mesh_type = "heightfield"
     Cfg.terrain.terrain_noise_magnitude = 0.01
+    Cfg.terrain.terrain_length = 1
+    Cfg.terrain.terrain_width = 1
+
 
     Cfg.domain_rand.lag_timesteps = 6
     Cfg.domain_rand.randomize_lag_timesteps = True
@@ -167,6 +170,8 @@ def play_go2(headless=True):
     joint_torques = np.zeros((num_eval_steps, 12))
 
     obs = env.reset()
+    env.set_main_agent_pose([1,1,1.5],[0,0,0,1])
+    
 
     foot_contacts = [False, False, False, False]
 
@@ -198,7 +203,8 @@ def play_go2(headless=True):
         # quat_indices = [1, 2, 3, 0]
         quat_indices = [0, 1, 2, 3]
         br.sendTransform(
-            ((base_pos[0] + 5) % 10 - 5, (base_pos[1] + 5) % 10 - 5, base_pos[2]),
+            # ((base_pos[0] + 5) % 10 - 5, (base_pos[1] + 5) % 10 - 5, base_pos[2]),
+            base_pos - np.array([5,5,0]), # TODO: Make this not hard-coded
             (
                 base_quat[quat_indices[0]],
                 base_quat[quat_indices[1]],
@@ -221,7 +227,7 @@ def play_go2(headless=True):
 
         foot_data = np.array(foot_data)
         foot_data = foot_data.reshape(-1, 3)
-        foot_data[:, :2] = (foot_data[:, :2] + 5) % 10 - 5
+        foot_data[:, :2] = (foot_data[:, :2] - 5)  # TODO: Make this not hard-coded
         sensor_pub.publish(Float32MultiArray(data=foot_data.ravel()))
 
         ###### -----------ldt---------------

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -201,18 +201,21 @@ def play_go2(headless=True):
         target_vel = target / np.sqrt(np.sum(np.square(target)))
         
 
-        target_xvel = target_vel[0]
-        target_yvel = target_vel[1]
+        target_xvel = target_vel[0] * 1.5
+        target_yvel = target_vel[1] * 0
         
-        # if target_yvel > 0.2:
-        #     yaw_cmd = -.5
-        # elif target_yvel < -0.2:
-        #     yaW_cmd = .5
+        if target_vel[1] * np.sign(target_vel[0]) > 0.2:
+            yaw_cmd = 1.5 * min(np.abs(target_vel[1]*3), 1)
+        elif target_vel[1] * np.sign(target_vel[0]) < -0.2:
+            yaw_cmd = -1.5 * min(np.abs(target_vel[1]*3), 1)
+        else:
+            yaw_cmd = 0
+
 
         # if np.abs(target_yvel) > 0.5:
         #     target_yvel /= a
 
-        yaw_cmd = 0
+        # yaw_cmd = 0
 
         # x_axis = quat_rotate_inverse(base_quat, torch.Tensor([[1.,0.,0.]]))
         # y_axis = quat_rotate_inverse(base_quat, torch.Tensor([[0.,1.,0.]]))

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,0 +1,270 @@
+import isaacgym
+
+assert isaacgym
+import torch
+import numpy as np
+import time
+
+import glob
+import pickle as pkl
+
+import rospy
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Header, Float32MultiArray
+import tf
+
+from go2_gym.envs import *
+from go2_gym.envs.base.legged_robot_config import Cfg
+from go2_gym.envs.go2.go2_config import config_go2
+from go2_gym.envs.go2.velocity_tracking import VelocityTrackingEasyEnv
+
+from tqdm import tqdm
+
+
+def load_policy(logdir):
+    body = torch.jit.load(logdir + "/checkpoints/body_latest.jit")
+    import os
+
+    adaptation_module = torch.jit.load(
+        logdir + "/checkpoints/adaptation_module_latest.jit"
+    )
+
+    def policy(obs, info={}):
+        i = 0
+        latent = adaptation_module.forward(obs["obs_history"].to("cpu"))
+        action = body.forward(torch.cat((obs["obs_history"].to("cpu"), latent), dim=-1))
+        info["latent"] = latent
+        return action
+
+    return policy
+
+
+def load_env(label, headless=False):
+    dirs = glob.glob(f"../runs/{label}/*")
+    logdir = sorted(dirs)[0]
+
+    with open(logdir + "/parameters.pkl", "rb") as file:
+        pkl_cfg = pkl.load(file)
+        print(pkl_cfg.keys())
+        cfg = pkl_cfg["Cfg"]
+        print(cfg.keys())
+
+        for key, value in cfg.items():
+            if hasattr(Cfg, key):
+                for key2, value2 in cfg[key].items():
+                    setattr(getattr(Cfg, key), key2, value2)
+
+    # turn off DR for evaluation script
+    Cfg.domain_rand.push_robots = False
+    Cfg.domain_rand.randomize_friction = False
+    Cfg.domain_rand.randomize_gravity = False
+    Cfg.domain_rand.randomize_restitution = False
+    Cfg.domain_rand.randomize_motor_offset = False
+    Cfg.domain_rand.randomize_motor_strength = False
+    Cfg.domain_rand.randomize_friction_indep = False
+    Cfg.domain_rand.randomize_ground_friction = False
+    Cfg.domain_rand.randomize_base_mass = False
+    Cfg.domain_rand.randomize_Kd_factor = False
+    Cfg.domain_rand.randomize_Kp_factor = False
+    Cfg.domain_rand.randomize_joint_friction = False
+    Cfg.domain_rand.randomize_com_displacement = False
+
+    Cfg.env.num_recording_envs = 1
+    Cfg.env.num_envs = 1
+    Cfg.terrain.num_rows = 5
+    Cfg.terrain.num_cols = 5
+    Cfg.terrain.border_size = 0
+    Cfg.terrain.center_robots = True
+    Cfg.terrain.center_span = 1
+    Cfg.terrain.teleport_robots = True
+
+    Cfg.domain_rand.lag_timesteps = 6
+    Cfg.domain_rand.randomize_lag_timesteps = True
+    # default control_typw is "actuator_net", you can also switch it to "P" to enable joint PD control
+    Cfg.control.control_type = "actuator_net"
+    Cfg.asset.flip_visual_attachments = True
+
+    from go2_gym.envs.wrappers.history_wrapper import HistoryWrapper
+
+    env = VelocityTrackingEasyEnv(sim_device="cuda:0", headless=False, cfg=Cfg)
+    env = HistoryWrapper(env)
+
+    # load policy
+    from ml_logger import logger
+    from go2_gym_learn.ppo_cse.actor_critic import ActorCritic
+
+    policy = load_policy(logdir)
+
+    return env, policy
+
+
+def play_go2(headless=True):
+    from ml_logger import logger
+
+    from pathlib import Path
+    from go2_gym import MINI_GYM_ROOT_DIR
+    import glob
+    import os
+
+    rospy.init_node("state_publisher", anonymous=True)
+    br = tf.TransformBroadcaster()
+    pub = rospy.Publisher("joint_states", JointState, queue_size=10)
+    sensor_pub = rospy.Publisher("sensor_data", Float32MultiArray, queue_size=10)
+    name = [
+        "FL_hip_joint",
+        "FL_thigh_joint",
+        "FL_calf_joint",
+        "FR_hip_joint",
+        "FR_thigh_joint",
+        "FR_calf_joint",
+        "RL_hip_joint",
+        "RL_thigh_joint",
+        "RL_calf_joint",
+        "RR_hip_joint",
+        "RR_thigh_joint",
+        "RR_calf_joint",
+    ]
+    velocity = []
+    effort = []
+
+    # label = "gait-conditioned-agility/pretrain-v0/train"
+    label = "gait-conditioned-agility/pretrain-go2/train"
+
+    env, policy = load_env(label, headless=headless)
+
+    num_eval_steps = 2500  # 250
+    gaits = {
+        "pronking": [0, 0, 0],
+        "trotting": [0.5, 0, 0],
+        "bounding": [0, 0.5, 0],
+        "pacing": [0, 0, 0.5],
+    }
+
+    # x_vel_cmd, y_vel_cmd, yaw_vel_cmd = 1.5, 0.0, 0.0
+    x_vel_cmd, y_vel_cmd, yaw_vel_cmd = 1.5, 0.0, 0.0
+    body_height_cmd = 0.0
+    step_frequency_cmd = 3.0  # 3.0
+    gait = torch.tensor(gaits["trotting"])
+    # gait = torch.tensor(gaits["pronking"])
+    footswing_height_cmd = 0.08
+    pitch_cmd = 0.0
+    roll_cmd = 0.0
+    stance_width_cmd = 0.25
+
+    measured_x_vels = np.zeros(num_eval_steps)
+    target_x_vels = np.ones(num_eval_steps) * x_vel_cmd
+    joint_positions = np.zeros((num_eval_steps, 12))
+    ###### -----------ldt---------------
+    joint_torques = np.zeros((num_eval_steps, 12))
+
+    obs = env.reset()
+
+    foot_contacts = [False, False, False, False]
+
+    for i in tqdm(range(num_eval_steps)):
+        with torch.no_grad():
+            actions = policy(obs)
+        env.commands[:, 0] = x_vel_cmd
+        env.commands[:, 1] = y_vel_cmd
+        env.commands[:, 2] = yaw_vel_cmd
+        env.commands[:, 3] = body_height_cmd
+        env.commands[:, 4] = step_frequency_cmd
+        env.commands[:, 5:8] = gait
+        env.commands[:, 8] = 0.5
+        env.commands[:, 9] = footswing_height_cmd
+        env.commands[:, 10] = pitch_cmd
+        env.commands[:, 11] = roll_cmd
+        env.commands[:, 12] = stance_width_cmd
+        obs, rew, done, info = env.step(actions)
+
+        measured_x_vels[i] = env.base_lin_vel[0, 0]
+        joint_positions[i] = env.dof_pos[0, :].cpu()
+
+        t = time.time()
+        header = Header(seq=0, stamp=rospy.Time(t), frame_id="World")
+        position = env.dof_pos[0, :].cpu()
+        pub.publish(JointState(header, name, position, velocity, effort))
+        base_pos = env.env.base_pos[0, :].cpu()
+        base_quat = env.env.base_quat[0, :].cpu()
+        # quat_indices = [1, 2, 3, 0]
+        quat_indices = [0, 1, 2, 3]
+        br.sendTransform(
+            ((base_pos[0] + 5) % 10 - 5, (base_pos[1] + 5) % 10 - 5, base_pos[2]),
+            (
+                base_quat[quat_indices[0]],
+                base_quat[quat_indices[1]],
+                base_quat[quat_indices[2]],
+                base_quat[quat_indices[3]],
+            ),
+            rospy.Time.now(),
+            "Base",
+            "World",
+        )
+
+        foot_data = []
+
+        for index, foot in enumerate(env.feet_indices):
+            foot_state = env.env.contact_forces[0, foot, 2] > 0
+            if foot_state and not foot_contacts[index]:
+                foot_data.append(env.env.foot_positions.detach().cpu().numpy())
+
+            foot_contacts[index] = foot_state
+
+        foot_data = np.array(foot_data)
+        foot_data = foot_data.reshape(-1, 3)
+        foot_data[:, :2] = (foot_data[:, :2] + 5) % 10 - 5
+        sensor_pub.publish(Float32MultiArray(data=foot_data.ravel()))
+
+        ###### -----------ldt---------------
+        # joint_torques[i] = env.torques.detach().cpu().numpy()
+
+    # plot target and measured forward velocity
+    from matplotlib import pyplot as plt
+
+    fig, axs = plt.subplots(3, 1, figsize=(12, 5))
+    axs[0].plot(
+        np.linspace(0, num_eval_steps * env.dt, num_eval_steps),
+        measured_x_vels,
+        color="black",
+        linestyle="-",
+        label="Measured",
+    )
+    axs[0].plot(
+        np.linspace(0, num_eval_steps * env.dt, num_eval_steps),
+        target_x_vels,
+        color="black",
+        linestyle="--",
+        label="Desired",
+    )
+    axs[0].legend()
+    axs[0].set_title("Forward Linear Velocity")
+    axs[0].set_xlabel("Time (s)")
+    axs[0].set_ylabel("Velocity (m/s)")
+
+    axs[1].plot(
+        np.linspace(0, num_eval_steps * env.dt, num_eval_steps),
+        joint_positions,
+        linestyle="-",
+        label="Measured",
+    )
+    axs[1].set_title("Joint Positions")
+    axs[1].set_xlabel("Time (s)")
+    axs[1].set_ylabel("Joint Position (rad)")
+
+    axs[2].plot(
+        np.linspace(0, num_eval_steps * env.dt, num_eval_steps),
+        joint_torques,
+        linestyle="-",
+        label="Measured",
+    )
+    axs[2].set_title("Joint Torques")
+    axs[2].set_xlabel("Time (s)")
+    axs[2].set_ylabel("Joint Torques (Nm)")
+
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    # to see the environment rendering, set headless=False
+    play_go2(headless=False)

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -181,7 +181,7 @@ def play_go2(headless=True):
     joint_torques = np.zeros((num_eval_steps, 12))
 
     obs = env.reset()
-    env.set_main_agent_pose([1,1,1.5],[0,0,0,1])
+    env.set_main_agent_pose([1,1,.5],[0,0,0,1])
     
 
     foot_contacts = [False, False, False, False]
@@ -264,17 +264,19 @@ def play_go2(headless=True):
 
         foot_data = []
 
-        for index, foot in enumerate(env.feet_indices):
-            foot_state = env.env.contact_forces[0, foot, 2] > 0
-            if foot_state and not foot_contacts[index]:
-                foot_data.append(env.env.foot_positions.detach().cpu().numpy())
+        if i > 100:
 
-            foot_contacts[index] = foot_state
+            for index, foot in enumerate(env.feet_indices):
+                foot_state = env.env.contact_forces[0, foot, 2] > 0
+                if foot_state and not foot_contacts[index]:
+                    foot_data.append(env.env.foot_positions.detach().cpu().numpy())
 
-        foot_data = np.array(foot_data)
-        foot_data = foot_data.reshape(-1, 3)
-        foot_data[:, :2] = (foot_data[:, :2] - 5)  # TODO: Make this not hard-coded
-        sensor_pub.publish(Float32MultiArray(data=foot_data.ravel()))
+                foot_contacts[index] = foot_state
+
+            foot_data = np.array(foot_data)
+            foot_data = foot_data.reshape(-1, 3)
+            foot_data[:, :2] = (foot_data[:, :2] - 5)  # TODO: Make this not hard-coded
+            sensor_pub.publish(Float32MultiArray(data=foot_data.ravel()))
 
         ###### -----------ldt---------------
         # joint_torques[i] = env.torques.detach().cpu().numpy()

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -84,6 +84,8 @@ def load_env(label, headless=False):
     Cfg.terrain.center_robots = True
     Cfg.terrain.center_span = 1
     Cfg.terrain.teleport_robots = True
+    Cfg.terrain.mesh_type = "heightfield"
+    Cfg.terrain.terrain_noise_magnitude = 0.01
 
     Cfg.domain_rand.lag_timesteps = 6
     Cfg.domain_rand.randomize_lag_timesteps = True

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,3 +1,4 @@
+#! /usr/bin/python
 import isaacgym
 
 assert isaacgym
@@ -9,6 +10,8 @@ import glob
 import pickle as pkl
 
 import rospy
+from pathlib import Path
+import rospkg
 from sensor_msgs.msg import JointState
 from std_msgs.msg import Header, Float32MultiArray
 import tf
@@ -40,7 +43,11 @@ def load_policy(logdir):
 
 
 def load_env(label, headless=False):
-    dirs = glob.glob(f"../runs/{label}/*")
+
+    # # If running without ros, use the next line instead of the two subsequent ones
+    # dirs = glob.glob(f"../runs/{label}/*")
+    robot = Path(rospkg.RosPack().get_path("robot"))
+    dirs = glob.glob(f"{robot}/go2_walking/runs/{label}/*")
     logdir = sorted(dirs)[0]
 
     with open(logdir + "/parameters.pkl", "rb") as file:


### PR DESCRIPTION
# Summary

Add following capabilities to Omniverse simulation with Walk These Ways:
- Add custom (hard-coded) heightfield (currently a product of sines)
- Walk towards a target location, either forwards or backwards
- Communicate with ROS
    - Get target (x, y)
    - Publish joint positions, base transform, foot contacts

The main file is `run.py`, which is a modified version of `play.py` that removes certain testing features (random initialization, teleportation if the robot goes off the edge, resets partway through, etc.)

![Omniverse](https://github.com/user-attachments/assets/e2288949-68df-4c14-b9a9-4a555c5c4d99)